### PR TITLE
Add `params.customHead` config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,9 @@ theme = "infinity-hugo"
 removePathAccents = true
 [params]
 
+# HTML before the closing </head>
+customHead = ""
+
 # Navigation
 [params.navigation]
 logo = "images/logo.png"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,6 +18,8 @@
     <link rel="stylesheet" href="{{ `css/style.css` | absURL }}">
     {{"<!-- Responsive Stylesheet -->" | safeHTML }}
     <link rel="stylesheet" href="{{ `css/responsive.css` | absURL }}">
+
+    {{ $.Site.Params.customHead | safeHTML }}
 </head>
 
 <body id="body">


### PR DESCRIPTION
To make easier to customize fonts or add code requested by widgets.

YAML sample:

```
params:

  customHead: >-
    <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,400i,500,700&display=swap" rel="stylesheet">
```